### PR TITLE
fix some issues with output format

### DIFF
--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -56,6 +56,7 @@ var timeout, stepsize time.Duration
 
 var keystoneDriver keystone.Driver
 var storageDriver storage.Driver
+var tzLocation = time.Local
 
 // recoverAll is used to turn panics into error output
 // we use panics here for any errors
@@ -72,6 +73,9 @@ func fetchToken() string {
 	// authenticate calls to Maia
 	if auth.TokenID != "" {
 		return auth.TokenID
+	}
+	if auth.Password == "$OS_PASSWORD" {
+		auth.Password = os.Getenv("OS_PASSWORD")
 	}
 	if (auth.Username == "" && auth.UserID == "") || auth.Password == "" {
 		panic(fmt.Errorf("You must at least specify --os-username / --os-user-id and --os-password"))
@@ -115,7 +119,7 @@ func printValues(resp *http.Response) {
 		if contentType == storage.JSON {
 			if strings.EqualFold(outputFormat, "json") {
 				fmt.Print(string(body))
-			} else if strings.EqualFold(outputFormat, "values") {
+			} else if strings.EqualFold(outputFormat, "value") {
 				var jsonResponse struct {
 					Value []string `json:"data,omitempty"`
 				}
@@ -130,7 +134,7 @@ func printValues(resp *http.Response) {
 				panic(fmt.Errorf("Unsupported --format value for this command: %s", outputFormat))
 			}
 		} else if strings.HasPrefix(contentType, "text/plain") {
-			if strings.EqualFold(outputFormat, "values") {
+			if strings.EqualFold(outputFormat, "value") {
 				fmt.Print(string(body))
 			} else {
 				panic(fmt.Errorf("Unsupported --format value for this command: %s", outputFormat))
@@ -155,7 +159,7 @@ func printTable(resp *http.Response) {
 			if strings.EqualFold(outputFormat, "json") {
 				fmt.Print(string(body))
 				return
-			} else if strings.EqualFold(outputFormat, "table") || strings.EqualFold(outputFormat, "values") {
+			} else if strings.EqualFold(outputFormat, "table") || strings.EqualFold(outputFormat, "value") {
 
 				// unmarshal
 				var jsonResponse struct {
@@ -215,7 +219,7 @@ func buildColumnSet(promResult model.Value) map[string]bool {
 }
 
 func printHeader(allColumns []string) {
-	if !strings.EqualFold(outputFormat, "values") {
+	if !strings.EqualFold(outputFormat, "value") {
 		for i, field := range allColumns {
 			if i > 0 {
 				fmt.Print(separator)
@@ -277,7 +281,7 @@ func printTemplate(body []byte, tpl string) {
 
 // timeColumnFromTS creates a table column for a timestamp; it rounds it off to the step-size
 func timeColumnFromTS(ts time.Time) string {
-	return ts.Truncate(stepsize).Format(time.RFC3339)
+	return ts.Truncate(stepsize).In(tzLocation).Format(time.RFC3339)
 }
 
 func printQueryResultAsTable(body []byte) {
@@ -317,7 +321,7 @@ func printQueryResultAsTable(body []byte) {
 		for _, el := range matrix {
 			collectKeys(set, model.LabelSet(el.Metric))
 			columnValues := map[string]string{}
-			columnValues[timestampKey] = el.Timestamp.Time().Format(time.RFC3339Nano)
+			columnValues[timestampKey] = el.Timestamp.Time().In(tzLocation).Format(time.RFC3339Nano)
 			columnValues[valueKey] = el.Value.String()
 			for labelKey, labelValue := range el.Metric {
 				columnValues[string(labelKey)] = string(labelValue)
@@ -328,7 +332,7 @@ func printQueryResultAsTable(body []byte) {
 	case model.ValScalar:
 		scalarValue := valueObject.(*model.Scalar)
 		allColumns = []string{timestampKey, valueKey}
-		rows = []map[string]string{{timestampKey: scalarValue.Timestamp.Time().Format(time.RFC3339Nano), valueKey: scalarValue.String()}}
+		rows = []map[string]string{{timestampKey: scalarValue.Timestamp.Time().In(tzLocation).Format(time.RFC3339Nano), valueKey: scalarValue.String()}}
 	}
 	printHeader(allColumns)
 	for _, row := range rows {
@@ -369,6 +373,8 @@ func Snapshot(cmd *cobra.Command, args []string) (ret error) {
 	// transform panics with error params into errors
 	defer recoverAll()
 
+	setDefaultOutputFormat("value")
+
 	prometheus := storageInstance()
 
 	var resp *http.Response
@@ -384,6 +390,8 @@ func Snapshot(cmd *cobra.Command, args []string) (ret error) {
 func LabelValues(cmd *cobra.Command, args []string) (ret error) {
 	// transform panics with error params into errors
 	defer recoverAll()
+
+	setDefaultOutputFormat("value")
 
 	// check parameters
 	if len(args) < 1 {
@@ -407,6 +415,8 @@ func Series(cmd *cobra.Command, args []string) (ret error) {
 	// transform panics with error params into errors
 	defer recoverAll()
 
+	setDefaultOutputFormat("table")
+
 	// pass the keystone token to Maia and ensure that the result is text
 	prometheus := storageInstance()
 
@@ -424,6 +434,8 @@ func MetricNames(cmd *cobra.Command, args []string) (ret error) {
 	// transform panics with error params into errors
 	defer recoverAll()
 
+	setDefaultOutputFormat("value")
+
 	return LabelValues(cmd, []string{"__name__"})
 }
 
@@ -431,6 +443,8 @@ func MetricNames(cmd *cobra.Command, args []string) (ret error) {
 func Query(cmd *cobra.Command, args []string) (ret error) {
 	// transform panics with error params into errors
 	defer recoverAll()
+
+	setDefaultOutputFormat("json")
 
 	// check parameters
 	if len(args) < 1 {
@@ -469,6 +483,12 @@ func Query(cmd *cobra.Command, args []string) (ret error) {
 	return nil
 }
 
+func setDefaultOutputFormat(format string) {
+	if outputFormat == "" {
+		outputFormat = format
+	}
+}
+
 // checkHttpStatus checks whether the response is 200 and panics with an appropriate error otherwise
 func checkResponse(err error, resp *http.Response) {
 	if err != nil {
@@ -479,14 +499,14 @@ func checkResponse(err error, resp *http.Response) {
 }
 
 var snapshotCmd = &cobra.Command{
-	Use:   "Snapshot [ --selector <vector-selector> ]",
+	Use:   "snapshot [ --selector <vector-selector> ]",
 	Short: "Get a Snapshot of the actual metric values for a project/domain.",
 	Long:  "Displays the current values of all metric Series. The Series can filtered using vector-selectors (label constraints).",
 	RunE:  Snapshot,
 }
 
 var seriesCmd = &cobra.Command{
-	Use:   "Series [ --selector <vector-selector> ] [ --start <starttime> --end <endtime> ]",
+	Use:   "series [ --selector <vector-selector> ] [ --start <starttime> --end <endtime> ]",
 	Short: "List measurement Series for project/domain.",
 	Long:  "Lists all metric Series. The Series can filtered using vector-selectors (label constraints).",
 	RunE:  Series,
@@ -507,7 +527,7 @@ var metricNamesCmd = &cobra.Command{
 }
 
 var queryCmd = &cobra.Command{
-	Use:   "Query <PromQL Query> [ --timestamp | --start <starttime> --end <endtime> --step <duration> ] [ --timeout <duration> ]",
+	Use:   "query <PromQL Query> [ --timestamp | --start <starttime> --end <endtime> --step <duration> ] [ --timeout <duration> ]",
 	Short: "Perform a PromQL Query",
 	Long:  "Performs a PromQL Query against the metrics available for the project/domain in scope",
 	RunE:  Query,
@@ -526,24 +546,42 @@ func init() {
 	// and all subcommands, e.g.:
 	// snapshotCmd.PersistentFlags().String("foo", "", "A help for foo")
 
+	// pass OpenStack auth. information via global top-level parameters or environment variables
+	// it is used by the "serve" command as service user, otherwise to authenticate the client
+	RootCmd.PersistentFlags().StringVar(&auth.IdentityEndpoint, "os-auth-url", os.Getenv("OS_AUTH_URL"), "OpenStack Authentication URL")
+	viper.BindPFlag("keystone.auth_url", RootCmd.PersistentFlags().Lookup("os-auth-url"))
+
+	RootCmd.PersistentFlags().StringVar(&auth.Username, "os-username", os.Getenv("OS_USERNAME"), "OpenStack Username")
+	RootCmd.PersistentFlags().StringVar(&auth.UserID, "os-user-id", os.Getenv("OS_USER_ID"), "OpenStack Username")
+	RootCmd.PersistentFlags().StringVar(&auth.Password, "os-password", "$OS_PASSWORD", "OpenStack Password")
+	RootCmd.PersistentFlags().StringVar(&auth.DomainName, "os-user-domain-name", os.Getenv("OS_USER_DOMAIN_NAME"), "OpenStack User's domain name")
+	RootCmd.PersistentFlags().StringVar(&auth.DomainID, "os-user-domain-id", os.Getenv("OS_USER_DOMAIN_ID"), "OpenStack User's domain ID")
+	RootCmd.PersistentFlags().StringVar(&auth.Scope.ProjectName, "os-project-name", os.Getenv("OS_PROJECT_NAME"), "OpenStack Project name to scope to")
+	RootCmd.PersistentFlags().StringVar(&auth.Scope.DomainName, "os-project-domain-name", os.Getenv("OS_PROJECT_DOMAIN_NAME"), "OpenStack Project's domain name")
+	RootCmd.PersistentFlags().StringVar(&scopedDomain, "os-domain-name", os.Getenv("OS_DOMAIN_NAME"), "OpenStack domain name to scope to")
+	RootCmd.PersistentFlags().StringVar(&auth.Scope.DomainID, "os-domain-id", os.Getenv("OS_DOMAIN_ID"), "OpenStack domain ID to scope to")
+	RootCmd.PersistentFlags().StringVar(&auth.TokenID, "os-token", os.Getenv("OS_TOKEN"), "OpenStack keystone token")
+
+	RootCmd.PersistentFlags().StringVarP(&outputFormat, "format", "f", "", "Specify output format: table, json, template or value")
+	RootCmd.PersistentFlags().StringVarP(&columns, "columns", "c", "", "Specify the columns to print (comma-separated; only when --format value is set)")
+	RootCmd.PersistentFlags().StringVar(&separator, "separator", " ", "Separate different columns with this string (only when --columns value is set; default <space>)")
+	RootCmd.PersistentFlags().StringVar(&jsonTemplate, "template", "", "Go-template to define a custom output format based on the JSON response (only when --format=template)")
+
+	RootCmd.PersistentFlags().StringVar(&maiaURL, "maia-url", os.Getenv("MAIA_URL"), "URL of the target Maia service (override OpenStack service catalog)")
+	RootCmd.PersistentFlags().StringVar(&promURL, "prometheus-url", os.Getenv("MAIA_PROMETHEUS_URL"), "URL of the Prometheus server backing Maia (MAIA_PROMETHEUS_URL)")
+	viper.BindPFlag("maia.prometheus_url", RootCmd.PersistentFlags().Lookup("prometheus-url"))
+
 	snapshotCmd.Flags().StringVarP(&selector, "selector", "l", "", "Prometheus label-selector to restrict the amount of metrics")
-	addClientFlags(snapshotCmd, "values")
 
 	queryCmd.Flags().StringVar(&starttime, "start", "", "Range Query: Start timestamp (RFC3339 or Unix format; default:earliest)")
 	queryCmd.Flags().StringVar(&endtime, "end", "", "Range Query: End timestamp (RFC3339 or Unix format; default: latest)")
 	queryCmd.Flags().StringVar(&timestamp, "timestamp", "", "Timestamp of measurement (RFC3339 or Unix format; default: latest)")
 	queryCmd.Flags().DurationVarP(&timeout, "timeout", "", 0, "Optional: Timeout for Query (e.g. 10m; default: server setting)")
 	queryCmd.Flags().DurationVarP(&stepsize, "step", "", 0, "Optional: Step size for range Query (e.g. 30s)")
-	addClientFlags(queryCmd, "json")
-
-	addClientFlags(labelValuesCmd, "values")
-
-	addClientFlags(metricNamesCmd, "values")
 
 	seriesCmd.Flags().StringVarP(&selector, "selector", "l", "", "Prometheus label-selector to restrict the amount of metrics")
 	seriesCmd.Flags().StringVar(&starttime, "start", "", "Start timestamp (RFC3339 or Unix format; default:earliest)")
 	seriesCmd.Flags().StringVar(&endtime, "end", "", "End timestamp (RFC3339 or Unix format; default: latest)")
-	addClientFlags(seriesCmd, "table")
 }
 
 func setKeystoneInstance(keystone keystone.Driver) {
@@ -552,31 +590,4 @@ func setKeystoneInstance(keystone keystone.Driver) {
 
 func setStorageInstance(storage storage.Driver) {
 	storageDriver = storage
-}
-
-func addClientFlags(cmd *cobra.Command, defaultOutputFormat string) {
-	// pass OpenStack auth. information via global top-level parameters or environment variables
-	// it is used by the "serve" command as service user, otherwise to authenticate the client
-	cmd.PersistentFlags().StringVar(&auth.IdentityEndpoint, "os-auth-url", os.Getenv("OS_AUTH_URL"), "OpenStack Authentication URL")
-	viper.BindPFlag("keystone.auth_url", cmd.PersistentFlags().Lookup("os-auth-url"))
-
-	cmd.PersistentFlags().StringVar(&auth.Username, "os-username", os.Getenv("OS_USERNAME"), "OpenStack Username")
-	cmd.PersistentFlags().StringVar(&auth.Username, "os-user-id", os.Getenv("OS_USER_ID"), "OpenStack Username")
-	cmd.PersistentFlags().StringVar(&auth.Password, "os-password", os.Getenv("OS_PASSWORD"), "OpenStack Password")
-	cmd.PersistentFlags().StringVar(&auth.DomainName, "os-user-domain-name", os.Getenv("OS_USER_DOMAIN_NAME"), "OpenStack User's domain name")
-	cmd.PersistentFlags().StringVar(&auth.DomainID, "os-user-domain-id", os.Getenv("OS_USER_DOMAIN_ID"), "OpenStack User's domain ID")
-	cmd.PersistentFlags().StringVar(&auth.Scope.ProjectName, "os-project-name", os.Getenv("OS_PROJECT_NAME"), "OpenStack Project name to scope to")
-	cmd.PersistentFlags().StringVar(&auth.Scope.DomainName, "os-project-domain-name", os.Getenv("OS_PROJECT_DOMAIN_NAME"), "OpenStack Project's domain name")
-	cmd.PersistentFlags().StringVar(&scopedDomain, "os-domain-name", os.Getenv("OS_DOMAIN_NAME"), "OpenStack domain name to scope to")
-	cmd.PersistentFlags().StringVar(&auth.Scope.DomainID, "os-domain-id", os.Getenv("OS_DOMAIN_ID"), "OpenStack domain ID to scope to")
-	cmd.PersistentFlags().StringVar(&auth.TokenID, "os-token", os.Getenv("OS_TOKEN"), "OpenStack keystone token")
-
-	cmd.PersistentFlags().StringVarP(&outputFormat, "format", "f", defaultOutputFormat, "Specify output format: table, json, template or value")
-	cmd.PersistentFlags().StringVarP(&columns, "columns", "c", "", "Specify the columns to print (comma-separated; only when --format value is set)")
-	cmd.PersistentFlags().StringVar(&separator, "separator", " ", "Separate different columns with this string (only when --columns value is set; default <space>)")
-	cmd.PersistentFlags().StringVar(&jsonTemplate, "template", "", "Go-template to define a custom output format based on the JSON response (only when --format=template)")
-
-	cmd.Flags().StringVar(&maiaURL, "maia-url", os.Getenv("MAIA_URL"), "URL of the target Maia service (override OpenStack service catalog)")
-	cmd.PersistentFlags().StringVar(&promURL, "storageInstance-url", os.Getenv("MAIA_PROMETHEUS_URL"), "URL of the Prometheus server backing Maia (MAIA_PROMETHEUS_URL)")
-	viper.BindPFlag("maia.prometheus_url", cmd.PersistentFlags().Lookup("storageInstance-url"))
 }

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -55,6 +55,7 @@ func setupTest(controller *gomock.Controller) (keystone.Driver, *storage.MockDri
 	// create dummy keystone and storage mock
 	keystone := keystone.Mock()
 	storage := storage.NewMockDriver(controller)
+	tzLocation = time.UTC
 
 	setKeystoneInstance(keystone)
 	setStorageInstance(storage)
@@ -71,7 +72,7 @@ func ExampleSnapshot() {
 
 	_, storageMock := setupTest(ctrl)
 
-	outputFormat = "vAlues"
+	outputFormat = "vAlue"
 	selector = "vmware_name=\"win_cifs_13\""
 	storageMock.EXPECT().Federate([]string{"{" + selector + "}"}, storage.PlainText).Return(test.HTTPResponseFromFile("fixtures/federate.txt"), nil)
 
@@ -81,7 +82,7 @@ func ExampleSnapshot() {
 	// vcenter_cpu_costop_summation{component="vcenter-exporter-vc-a-0",instance="100.65.0.252:9102",instance_uuid="3b32f415-c953-40b9-883d-51321611a7d4",job="endpoints",kubernetes_name="vcenter-exporter-vc-a-0",kubernetes_namespace="maia",metric_detail="3",project_id="12345",region="staging",service="metrics",system="openstack",vcenter_name="STAGINGA",vcenter_node="10.44.2.40",vmware_name="win_cifs_13"} 0 1500291187275
 }
 
-func ExampleSeries() {
+func ExampleSeries_json() {
 	t := testReporter{}
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -116,6 +117,27 @@ func ExampleSeries() {
 	// }
 }
 
+func ExampleSeries_table() {
+	t := testReporter{}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, storageMock := setupTest(ctrl)
+
+	selector = "component!=\"\""
+	starttime = "2017-07-01T20:10:30.781Z"
+	endtime = "2017-07-02T04:00:00.000Z"
+	outputFormat = "table"
+
+	storageMock.EXPECT().Series([]string{"{" + selector + "}"}, starttime, endtime, storage.JSON).Return(test.HTTPResponseFromFile("fixtures/series.json"), nil)
+
+	seriesCmd.RunE(seriesCmd, []string{})
+
+	// Output:
+	// __name__ component instance job kubernetes_name kubernetes_namespace os_cluster region system
+	// up objectstore 100.64.1.159:9102 endpoints swift-proxy-cluster-3 swift cluster-3 staging openstack
+}
+
 func ExampleLabelValues_json() {
 	t := testReporter{}
 	ctrl := gomock.NewController(t)
@@ -147,7 +169,7 @@ func ExampleLabelValues_values() {
 	_, storageMock := setupTest(ctrl)
 
 	labelName := "component"
-	outputFormat = "VaLueS"
+	outputFormat = "VaLue"
 
 	storageMock.EXPECT().LabelValues(labelName, storage.JSON).Return(test.HTTPResponseFromFile("fixtures/label_values.json"), nil)
 
@@ -199,7 +221,7 @@ func ExampleQuery_table() {
 
 	_, storageMock := setupTest(ctrl)
 
-	timestamp = "2017-07-01T20:10:30.781Z"
+	timestamp = "2017-07-03T07:26:23.997Z"
 	timeoutStr := "1440s"
 	timeout, _ = time.ParseDuration(timeoutStr)
 	query := "sum(blackbox_api_status_gauge{check=~\"keystone\"})"
@@ -221,8 +243,8 @@ func ExampleQuery_rangeJSON() {
 
 	_, storageMock := setupTest(ctrl)
 
-	starttime = "2017-07-01T20:10:30.781Z"
-	endtime = "2017-07-02T04:00:00.000Z"
+	starttime = "2017-07-13T20:10:30.781Z"
+	endtime = "2017-07-13T20:15:00.781Z"
 	stepsizeStr := "300s"
 	stepsize, _ = time.ParseDuration(stepsizeStr)
 	timeoutStr := "90s"
@@ -265,8 +287,8 @@ func ExampleQuery_rangeValuesTable() {
 
 	_, storageMock := setupTest(ctrl)
 
-	starttime = "2017-07-01T20:10:30.781Z"
-	endtime = "2017-07-02T04:00:00.000Z"
+	starttime = "2017-07-13T20:10:30.000Z"
+	endtime = "2017-07-13T20:15:00.000Z"
 	stepsizeStr := "300s"
 	stepsize, _ = time.ParseDuration(stepsizeStr)
 	timeoutStr := "90s"
@@ -290,8 +312,8 @@ func ExampleQuery_rangeSeriesTable() {
 
 	_, storageMock := setupTest(ctrl)
 
-	starttime = "2017-07-22T20:10:00.000+02:00"
-	endtime = "2017-07-22T20:20:00.000+02:00"
+	starttime = "2017-07-22T20:10:00.000Z"
+	endtime = "2017-07-22T20:20:00.000Z"
 	stepsizeStr := "300s"
 	stepsize, _ = time.ParseDuration(stepsizeStr)
 	timeoutStr := "90s"

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -233,7 +233,7 @@ func ExampleQuery_table() {
 
 	// Output:
 	// __timestamp__ __value__
-	// 2017-07-03T09:26:23.997+02:00 0
+	// 2017-07-03T07:26:23.997Z 0
 }
 
 func ExampleQuery_rangeJSON() {
@@ -301,7 +301,7 @@ func ExampleQuery_rangeValuesTable() {
 	queryCmd.RunE(queryCmd, []string{query})
 
 	// Output:
-	// 2017-07-13T22:10:00+02:00 2017-07-13T22:15:00+02:00
+	// 2017-07-13T20:10:00Z 2017-07-13T20:15:00Z
 	// 0 1
 }
 
@@ -327,6 +327,6 @@ func ExampleQuery_rangeSeriesTable() {
 	queryCmd.RunE(queryCmd, []string{query})
 
 	// Output:
-	// check instance region 2017-07-22T22:10:00+02:00 2017-07-22T22:15:00+02:00 2017-07-22T22:20:00+02:00
+	// check instance region 2017-07-22T20:10:00Z 2017-07-22T20:15:00Z 2017-07-22T20:20:00Z
 	// keystone 100.64.0.102:9102 staging 0 1 0
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -56,23 +56,9 @@ func setDefaultConfig() {
 	viper.SetDefault("keystone.token_cache_time", "900s")
 }
 
-func readConfig(configPath string) {
-	// Read the maia config file (required for server)
-	// That way an OpenStack client environment will not be accidentally used for the "serve" command
-	if _, err := os.Stat(configPath); err == nil {
-		viper.SetConfigFile(configPath)
-		viper.SetConfigType("toml")
-		err := viper.ReadInConfig()
-		if err != nil { // Handle errors reading the config file
-			panic(fmt.Errorf("Fatal error config file: %s", err))
-		}
-	}
-}
-
 func init() {
 	cobra.OnInitialize(func() {
 		setDefaultConfig()
-		readConfig(configFile)
 	})
 
 	RootCmd.PersistentFlags().StringVarP(&configFile, "config-file", "", "/etc/maia/maia.conf", "Configuration file to use")

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -40,18 +40,38 @@ var serveCmd = &cobra.Command{
 			}
 		}()
 
-		if _, err := os.Stat(configFile); err != nil {
-			panic(fmt.Errorf("No config file found at %s (required for server mode)", configFile))
-		}
-
 		// just run the server
 		api.Server()
 
 		return nil
 	},
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if _, err := os.Stat(configFile); err != nil {
+			panic(fmt.Errorf("No config file found at %s (required for server mode)", configFile))
+		}
+
+		readConfig(configFile)
+	},
+}
+
+func readConfig(configPath string) {
+	// Read the maia config file (required for server)
+	// That way an OpenStack client environment will not be accidentally used for the "serve" command
+	if _, err := os.Stat(configPath); err == nil {
+		viper.SetConfigFile(configPath)
+		viper.SetConfigType("toml")
+		err := viper.ReadInConfig()
+		if err != nil { // Handle errors reading the config file
+			panic(fmt.Errorf("Fatal error config file: %s", err))
+		}
+	}
 }
 
 func init() {
+	//	cobra.OnInitialize(func() {
+	//		readConfig(configFile)
+	//	})
+
 	RootCmd.AddCommand(serveCmd)
 
 	// Here you will define your flags and configuration settings.

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -162,7 +162,7 @@ func NewPrometheusDriver(prometheusAPIURL string, customHeader map[string]string
 			util.LogFatal("Couldn't initialize Prometheus storage driver with given endpoint: \"%s\"", prometheusAPIURL)
 			return nil
 		}
-		util.LogInfo("Using Prometheus at: \"%s\"", prometheusAPIURL)
+		util.LogInfo("Using API server at: \"%s\"", prometheusAPIURL)
 
 		return driver
 	default:


### PR DESCRIPTION
fixed issues:
* output format default were somehow mixed up between commands
* $OS_PASSWORD contents were shown by maia --help (being defaults)

other changes:
* common client parameters now attached to root command to avoid above issue with mixed-up defaults (most of them ignored by `serve` command)