### PR TITLE
Catalog discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ either OpenStack identity tokens or basic authentication.
 
 The service is configured using a TOML configuration file that is usually located in `etc/maia/maia.conf`. This file
 contains settings for the connection to Prometheus, the integration with OpenStack identity and technical configuration
-like the bind-address of the server process.
+like the bind-address of the server process. You can always override the entries of this file using command line parameters.
 
 Use the example in the `etc` folder of this repo to get started. 
 
@@ -147,6 +147,14 @@ this amount can be changed:
 token_cache_time = "3600s"
 ```
 
+## Starting the Service
+
+Once you have finalized the configuration file, you are set to go
+
+```
+maia serve
+```
+
 ## Available Exporters
 
 As explained in the Concept chapter, Maia requires all series to be labelled with OpenStack project_id resp. domain_id.
@@ -158,14 +166,6 @@ controlled VCenter.
 SNMP variables into labels. Since most of the SNMP-enabled devices are shared, only a few metrics can be mapped to
 OpenStack projects or domains.
 
-
-## Starting the Service
-
-Once you have finalized the configuration file, you are set to go
-
-```
-maia serve
-```
 
 ## Notes on Scalability
 
@@ -203,7 +203,8 @@ Use `openstack token issue` to generate a token and pass it to the Maia CLI in t
 export OS_TOKEN=$(openstack token issue -c id -f value)
 ```
  
-If Maia does not have a catalog entry, then you have to specify the Maia endpoint URL manually:
+If for some reason you want to use another Maia endpoint than the one registered in the OpenStack service catalog,
+then you can override its URL using the `--maia-url` option:
 
 | Option | Environment Variable | Description |
 |--------|----------------------|-------------|

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Maia
 
-Maia is a multi-tenant OpenStack-service for accessing metrics and alarms collected through Prometheus. It offers a [Prometheus-compatible](https://prometheus.io/docs/querying/api/) 
-API and supports federation.
+Maia is a multi-tenant OpenStack-service for accessing metrics and alarms collected through Prometheus. It offers 
+a [Prometheus-compatible](https://prometheus.io/docs/querying/api/) API and supports federation.
 
 At SAP we use it to share tenant-specific metrics from our Converged Cloud platform
 with our users. For their convenience we included a CLI, so that metrics can be discovered and
@@ -25,17 +25,20 @@ Maia CLI
 
 ## Concept
 
-Maia adds multi-tenant support to Prometheus by using dedicated labels to assign metrics to OpenStack projects and domains.
+Maia adds multi-tenant support to an existing Prometheus installation by using dedicated labels to assign metrics to
+OpenStack projects and domains. These labels either have to be supplied by the exporters or they have to be
+mapped from other labels using the [Prometheus relabelling](https://prometheus.io/docs/operating/configuration/#relabel_config)
+capabilities.
  
-The following labels have a special meaning in Maia. *Only metrics with these labels are visible though the Maia API.*
+The following labels have a special meaning in Maia. *Only metrics with these labels are visible through the Maia API.*
  
  | Label Key  | Description  |
  |------------|--------------|
  | project_id | OpenStack project UUID |
  | domain_id  | OpenStack domain UUID |
  
-Metrics without `domain_id` will not be available when authorized to domain scope. Likewise, metrics without `project_id`
-will be omitted when project scope is used. There is no inheritance of metrics to parent projects. Users authorized
+Metrics without `project_id` will be omitted when project scope is used. Likewise, metrics without `domain_id` will not
+be available when authorized to domain scope. There is no inheritance of metrics to parent projects. Users authorized
 to a domain will be able to access the metrics of all projects in that domain that have been labelled for the domain.
 
 # Installation
@@ -143,6 +146,18 @@ this amount can be changed:
 ```
 token_cache_time = "3600s"
 ```
+
+## Available Exporters
+
+As explained in the Concept chapter, Maia requires all series to be labelled with OpenStack project_id resp. domain_id.
+
+The following exporters are known to produce suitible metrics:
+* [VCenter Exporter](https://github.com/sapcc/vcenter-exporter) provides project-specific metrics from an OpenStack-
+controlled VCenter. 
+* [SNMP Exporter](https://github.com/prometheus/snmp_exporter) can be configured to extract project IDs from
+SNMP variables into labels. Since most of the SNMP-enabled devices are shared, only a few metrics can be mapped to
+OpenStack projects or domains.
+
 
 ## Starting the Service
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -97,7 +97,7 @@ func Test_LabelValues(t *testing.T) {
 	}.Check(t, router)
 }
 
-func Test_Query(t *testing.T) {
+func TestQuery(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -114,7 +114,22 @@ func Test_Query(t *testing.T) {
 	}.Check(t, router)
 }
 
-func Test_QueryRange(t *testing.T) {
+func TestQuery_syntaxError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	router, _, _ := setupTest(t, ctrl)
+
+	test.APIRequest{
+		Headers:          map[string]string{"Authorization": base64.StdEncoding.EncodeToString([]byte("Basic user_id@12345:password")), "Accept": "application/json"},
+		Method:           "GET",
+		Path:             "/api/v1/query?query=sum(blackbox_api_status_gauge{check%3D~%22keystone%22}&time=2017-07-01T20:10:30.781Z&timeout=24m",
+		ExpectStatusCode: 400,
+		ExpectJSON:       "fixtures/query_syntax_error.json",
+	}.Check(t, router)
+}
+
+func TestQueryRange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -131,7 +146,7 @@ func Test_QueryRange(t *testing.T) {
 	}.Check(t, router)
 }
 
-func Test_APIMetadata(t *testing.T) {
+func TestAPIMetadata(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/pkg/api/fixtures/query_syntax_error.json
+++ b/pkg/api/fixtures/query_syntax_error.json
@@ -1,0 +1,5 @@
+{
+  "Status": "error",
+  "ErrorType": "bad_data",
+  "error": "parse error at char 49: unclosed left parenthesis"
+}

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -42,7 +42,6 @@ func (r testReporter) Fatalf(format string, args ...interface{}) {
 
 func setupTest(controller *gomock.Controller) (keystone.Driver, *storage.MockDriver) {
 	// set mandatory parameters
-	maiaURL = "dummy"
 	auth.UserID = "user_id"
 	auth.Password = "password"
 	auth.Scope.ProjectID = "12345"
@@ -177,6 +176,27 @@ func ExampleLabelValues_values() {
 
 	// Output:
 	// objectstore
+}
+
+func ExampleMetricNames_values() {
+	t := testReporter{}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	maiaURL = "http://localhost:9091"
+	_, storageMock := setupTest(ctrl)
+
+	outputFormat = "valuE"
+
+	storageMock.EXPECT().LabelValues("__name__", storage.JSON).Return(test.HTTPResponseFromFile("fixtures/metric_names.json"), nil)
+
+	metricNamesCmd.RunE(metricNamesCmd, []string{})
+
+	// Output:
+	// vcenter_cpu_costop_summation
+	// vcenter_cpu_demand_average
+	// vcenter_cpu_idle_summation
+	// vcenter_cpu_latency_average
 }
 
 func ExampleQuery_json() {

--- a/pkg/cmd/fixtures/metric_names.json
+++ b/pkg/cmd/fixtures/metric_names.json
@@ -1,0 +1,9 @@
+{
+  "Status": "success",
+  "data": [
+    "vcenter_cpu_costop_summation",
+    "vcenter_cpu_demand_average",
+    "vcenter_cpu_idle_summation",
+    "vcenter_cpu_latency_average"
+  ]
+}

--- a/pkg/keystone/interface.go
+++ b/pkg/keystone/interface.go
@@ -33,11 +33,12 @@ import (
 type Driver interface {
 	// AuthenticateRequest authenticates a user using authOptionsFromRequest passed in the HTTP request header.
 	// After successful authentication, additional context information is added to the request header
-	// In addition a Context object is returned.
+	// In addition a Context object is returned for policy evaluation.
 	AuthenticateRequest(req *http.Request) (*policy.Context, error)
 
-	// Authenticate authenticates a user using the provided authOptionsFromRequest
-	Authenticate(options *tokens.AuthOptions) (*policy.Context, error)
+	// Authenticate authenticates a user using the provided authOptions.
+	// It returns a context for policy evaluation and the public endpoint retrieved from the service catalog
+	Authenticate(options *tokens.AuthOptions) (*policy.Context, string, error)
 }
 
 // NewKeystoneDriver is a factory method which chooses the right driver implementation based on configuration settings

--- a/pkg/keystone/mock.go
+++ b/pkg/keystone/mock.go
@@ -32,9 +32,9 @@ func Mock() Driver {
 	return mock{}
 }
 
-func (d mock) Authenticate(credentials *tokens.AuthOptions) (*policy.Context, error) {
+func (d mock) Authenticate(credentials *tokens.AuthOptions) (*policy.Context, string, error) {
 	return &policy.Context{Request: map[string]string{"user_id": credentials.UserID,
-		"project_id": credentials.Scope.ProjectID, "password": credentials.Password}}, nil
+		"project_id": credentials.Scope.ProjectID, "password": credentials.Password}}, "http://localhost:9091", nil
 }
 
 func (d mock) AuthenticateRequest(req *http.Request) (*policy.Context, error) {


### PR DESCRIPTION
discovery Maia service using keystone catalog
* Maia CLI searches Keystone catalog for public Maia service when neither --prometheus-url nor --maia-url are specified but --os-auth-url is 
* misc. improvements to docu.

Closes #5


