### PR TITLE
Perform well even when the user has 1000+ projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: false
 
 go:
-    - 1.8
+    - 1.11
 
 install:
     - go get -u github.com/Masterminds/glide

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.9
 
 LABEL "maintainer"="Joachim Barheine <joachim.barheine@sap.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ clean: FORCE
 build/docker.tar:
 	glide install -v
 ifeq ($(OS), Darwin)
-	docker run --rm -v "$$PWD":"/go/src/github.com/sapcc/maia" -w "/go/src/github.com/sapcc/maia" -e "GOPATH=/go" golang:1.11-stretch env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
+	docker run --rm -v "$$PWD":"/go/src/github.com/sapcc/maia" -w "/go/src/github.com/sapcc/maia" -e "GOPATH=/go" golang:1.11-stretch env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
 else
 	env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
 endif

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: clean dependencies build check
 
 # This target uses the incremental rebuild capabilities of the Go compiler to speed things up.
 # If no source files have changed, `go install` exits quickly without doing anything.
-generate: FORCE
+generate: dependencies FORCE
 	# generate mocks
 	mockgen --source pkg/storage/interface.go --destination pkg/storage/genmock.go --package storage
 	mockgen --source pkg/keystone/interface.go --destination pkg/keystone/genmock.go --package keystone
@@ -68,8 +68,7 @@ clean: FORCE
 	rm -f pkg/storage/genmock.go
 	rm -f pkg/keystone/genmock.go
 
-build/docker.tar:
-	glide install -v
+build/docker.tar: dependencies
 ifeq ($(OS), Darwin)
 	docker run --rm -v "$$PWD":"/go/src/github.com/sapcc/maia" -w "/go/src/github.com/sapcc/maia" -e "GOPATH=/go" golang:1.11-stretch env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
 else

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ clean: FORCE
 build/docker.tar:
 	glide install -v
 ifeq ($(OS), Darwin)
-	docker run --rm -v "$$PWD":"/go/src/github.com/sapcc/maia" -w "/go/src/github.com/sapcc/maia" -e "GOPATH=/go" golang:1.8 env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
+	docker run --rm -v "$$PWD":"/go/src/github.com/sapcc/maia" -w "/go/src/github.com/sapcc/maia" -e "GOPATH=/go" golang:1.10 env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
 else
 	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
 endif

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,9 @@ clean: FORCE
 build/docker.tar:
 	glide install -v
 ifeq ($(OS), Darwin)
-	docker run --rm -v "$$PWD":"/go/src/github.com/sapcc/maia" -w "/go/src/github.com/sapcc/maia" -e "GOPATH=/go" golang:1.10 env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
+	docker run --rm -v "$$PWD":"/go/src/github.com/sapcc/maia" -w "/go/src/github.com/sapcc/maia" -e "GOPATH=/go" golang:1.11-stretch env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
 else
-	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
+	env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w -linkmode external -extldflags -static' -o maia_linux_amd64
 endif
 	tar cf - ./maia_linux_amd64 > build/docker.tar
 
@@ -82,7 +82,7 @@ DOCKER_IMAGE := hub.global.cloud.sap/monsoon/maia
 DOCKER_TAG   := latest
 
 docker: build/docker.tar
-	$(DOCKER) build --build-arg https_proxy=$$(HTTP_PROXY) --build-arg http_proxy=$$(HTTP_PROXY) --build-arg HTTP_PROXY=$$(HTTP_PROXY) --build-arg HTTPS_PROXY=$$(HTTP_PROXY) -t "$(DOCKER_IMAGE):$(DOCKER_TAG)" .
+	$(DOCKER) build -t "$(DOCKER_IMAGE):$(DOCKER_TAG)" .
 
 vendor: FORCE
 	glide update -v

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 294e488306a73402e7d5f48914c401bb940357d665c67f4caad631ccc8caa88f
-updated: 2017-08-22T10:18:26.40280047+02:00
+hash: 87b713fa4cf990f7af02ed053dae3f9cdf5c276a50ef7addd35b90fa8e34a526
+updated: 2019-02-21T13:12:32.139205+01:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -8,25 +8,25 @@ imports:
 - name: github.com/alecthomas/units
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/databus23/goslo.policy
   version: 3ae74dd07ebf48d1f2babbd1d2177cd1878a09ee
 - name: github.com/fsnotify/fsnotify
-  version: 4da3e2cfbabc9f751898f250b49f2439785783a1
+  version: ccc981bf80385c528a65fbfdd49bf2d8da22aa23
 - name: github.com/golang/mock
-  version: 1df903b45f27b0b3685fa78609b653a54c7eead8
+  version: c20582278a829e4b3259747a3ce0eceb1763ee13
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
+  version: c823c79ea1570fb5ff454033735a8e68575d1d0f
   subpackages:
   - proto
 - name: github.com/golang/snappy
-  version: 553a641470496b2327abcac10b36396bd98e45c9
+  version: 2a8bb927dd31d8daada140a5d09578521ce5c36a
 - name: github.com/gophercloud/gophercloud
-  version: 7b1de057e52e9cae660ed44f8cfe0c923ddb4c04
+  version: d6801284f5e8eb368096bcdef55f81a33eb16b23
   subpackages:
   - internal
   - openstack
@@ -39,15 +39,14 @@ imports:
   - openstack/identity/v3/users
   - openstack/utils
   - pagination
-- name: github.com/gorilla/context
-  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: bcd8bc72b08df0f70df986b97f95590779502d31
+  version: a7962380ca08b5a188038c69871b8d3fbdf31e89
 - name: github.com/hashicorp/hcl
-  version: 392dba7d905ed5d04a5794ba89f558b27e2ba1ca
+  version: 65a6292f0157eff210d03ed1bf6c59b190b8b906
   subpackages:
   - hcl/ast
   - hcl/parser
+  - hcl/printer
   - hcl/scanner
   - hcl/strconv
   - hcl/token
@@ -57,23 +56,25 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jteeuwen/go-bindata
-  version: a0ff2567cfb70903282db057e799fd826784d41d
+  version: 6025e8de665b31fa74ab1a66f2cddd8c0abf887e
+- name: github.com/konsorten/go-windows-terminal-sequences
+  version: 5c8c8bd35d3832f5d134ae1e1e375b69a4d25242
 - name: github.com/magiconair/properties
-  version: be5ece7dd465ab0765a9682137865547526d1dfb
+  version: 7757cc9fdb852f7579b24170bcacda2c7471bb6a
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  version: c182affec369e30f25d3eb8cd8a478dee585ae7d
   subpackages:
   - pbutil
 - name: github.com/mitchellh/mapstructure
-  version: d0303fe809921458f417bcf828397a65db30a7e4
+  version: 3536a929edddb9a5b34bd6861dc4a9647cb459fe
 - name: github.com/opentracing/opentracing-go
-  version: 8ebe5d4e236eed9fd88e593c288bfb804d630b8c
+  version: 25a84ff92183e2f8ac018ba1db54f8a07b3c0e04
   subpackages:
   - log
 - name: github.com/patrickmn/go-cache
-  version: a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0
+  version: 5633e0862627c011927fa39556acae8b1f1df58a
 - name: github.com/pelletier/go-toml
-  version: 4692b8f9babfc93db58cc592ba2689d8736781de
+  version: 27c6b39a135b7dc87a14afb068809132fb7a9a8f
 - name: github.com/prometheus/client_golang
   version: 94ff84a9a6ebb5e6eb9172897c221a64df3443bc
   subpackages:
@@ -81,22 +82,25 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  version: fd36f4220a901265f90734c3183c5f0c91daa0b8
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
+  version: 7a3416fd1f41341905f138746c51a5092e7ddf7a
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - log
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  version: e4d4a2206da023361ed100d85c5f2cf9c8364e9f
   subpackages:
+  - internal/util
+  - iostats
+  - nfs
   - xfs
 - name: github.com/prometheus/prometheus
-  version: 3afb3fffa3a29c3de865e1172fb740442e9d0133
+  version: 5211b96d4d1291c3dd1a569f711d3b301b635ecb
   subpackages:
   - promql
   - storage
@@ -110,25 +114,25 @@ imports:
   - util/strutil
   - util/testutil
 - name: github.com/rs/cors
-  version: eabcc6af4bbe5ad3a949d36450326a2b0b9894b8
+  version: 76f58f330d76a55c5badc74f6212e8a15e742c77
 - name: github.com/sirupsen/logrus
-  version: 68806b4b77355d6c8577a2c8bbc6d547a5272491
+  version: 4f5fd631f16452fbd023813c1eb7dbd67130cb0c
 - name: github.com/spf13/afero
-  version: 9be650865eab0c12963d8753212f4f9c66cdcf12
+  version: f4711e4db9e9a1d3887343acb72b2bbfc2f686f5
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
+  version: 8c9545af88b134710ab1cd196795e7f2388358d7
 - name: github.com/spf13/cobra
-  version: cb731b898346822cc0c225c28550a8a29d93c732
+  version: 7547e83b2d85fd1893c7d76916f67689d761fecb
 - name: github.com/spf13/jwalterweatherman
-  version: 0efa5202c04663c757d84f90f5219c1250baf94f
+  version: 94f6ae3ed3bceceafa716478c5fbf8d29ca601a1
 - name: github.com/spf13/pflag
-  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
+  version: 24fa6976df40757dce6aea913e7b81ade90530e1
 - name: github.com/spf13/viper
-  version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
+  version: d104d259b3380cb653bb793756823c3c41b37b53
 - name: github.com/syndtr/goleveldb
-  version: b89cc31ef7977104127d34c1bd31ebd1a9db2199
+  version: 2f17a3356c6616cbfc4ae4c38147dc062a68fb0e
   subpackages:
   - leveldb
   - leveldb/cache
@@ -143,41 +147,43 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: golang.org/x/crypto
-  version: b176d7def5d71bdd214203491f89843ed217f420
+  version: a4c6cb3142f211c99e4bf4cd769535b29a9b616f
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  version: 3a22650c66bd7f4fb6d1e8072ffd7b75c8a27898
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: 43e60d72a8e2bd92ee98319ba9a384a0e9837c08
+  version: b4e8571b14e03cc164df06f72b640ebce3899579
   subpackages:
   - unix
   - windows
   - windows/registry
   - windows/svc/eventlog
 - name: golang.org/x/text
-  version: e56139fd9c5bc7244c76116c68e500765bb6db6b
+  version: 6c92c7dc7f53607809182301b96e4cc1975143f1
   subpackages:
   - transform
   - unicode/norm
 - name: gopkg.in/alecthomas/kingpin.v2
-  version: 1087e65c9441605df944fb12c33f0fe7072d18ca
+  version: 947dcec5ba9c011838740e680966fd7087a71d0d
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: 51d6538a90f86fe93ac480b35f37b2be17fef232
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: d8f796af33cc11cb798c1aaeb27a4ebc5099927d
   subpackages:
   - spew
 - name: github.com/h2non/gock
-  version: 379ef22cc09e3697c64bcc643eda9fd6fb94a932
+  version: ba88c4862a27596539531ce469478a91bc5a0511
+- name: github.com/h2non/parth
+  version: b4df798d65426f8c8ab5ca5f9987aec5575d26c9
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 5d4384ee4fb2527b0a1256a821ebfc92f91efefc
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  version: 3f658bd5ac42cc0b5de5b427e95a480d5726ea76
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,7 +7,7 @@ import:
   - openstack
   - openstack/identity/v3/tokens
 - package: github.com/gorilla/mux
-  version: ~1.4.0
+  version: ~1.7
 - package: github.com/prometheus/client_golang
   version: 94ff84a9a6ebb5e6eb9172897c221a64df3443bc 
   subpackages:
@@ -21,7 +21,7 @@ import:
   - expfmt
   - model
 - package: github.com/prometheus/prometheus
-  version: ~1.7.1
+  version: ~1.8
   subpackages:
   - promql
   - storage/metric

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -114,8 +114,8 @@ func ReturnJSON(w http.ResponseWriter, code int, data interface{}) {
 	if err == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(code)
-		// TODO: @Arno, what is this good for?
-		// payload := bytes.Replace(playload, []byte("\\u0026"), []byte("&"), -1)
+		// restore "&" in links that are broken by the json.Marshaller
+		payload := bytes.Replace(payload, []byte("\\u0026"), []byte("&"), -1)
 		w.Write(payload)
 	} else {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -21,13 +21,14 @@ package cmd
 
 import (
 	"fmt"
+	"time"
+
 	policy "github.com/databus23/goslo.policy"
 	"github.com/golang/mock/gomock"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/sapcc/maia/pkg/keystone"
 	"github.com/sapcc/maia/pkg/storage"
 	"github.com/sapcc/maia/pkg/test"
-	"time"
 )
 
 type testReporter struct {
@@ -35,11 +36,11 @@ type testReporter struct {
 }
 
 func (r testReporter) Errorf(format string, args ...interface{}) {
-	panic(fmt.Errorf(format, args))
+	panic(fmt.Errorf(format, args...))
 }
 
 func (r testReporter) Fatalf(format string, args ...interface{}) {
-	panic(fmt.Errorf(format, args))
+	panic(fmt.Errorf(format, args...))
 }
 
 func setupTest(controller *gomock.Controller) (*keystone.MockDriver, *storage.MockDriver) {


### PR DESCRIPTION
* use cache for project scope info to avoid 1000+ project details calls on first login to UI
* other: refresh global list of domains and roles when reauthenticating service user to avoid issues when introducing new roles or adding domains

@Closes #38 