### PR TITLE
fix endless redirect when switching domains

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -110,7 +110,10 @@ func redirectToDomainRootPage(w http.ResponseWriter, r *http.Request) {
 		redirectToRootPage(w, r)
 		return
 	}
-	newPath := "/" + domain + "/graph?" + r.URL.RawQuery // keep the query part since this is where the token might go
+	newPath := "/" + domain + "/graph"
+	if r.URL.RawQuery != "" {
+		newPath += "?" + r.URL.RawQuery // keep the query part since this is where the token might go
+	}
 	util.LogDebug("Redirecting %s to %s", r.URL.Path, newPath)
 	http.Redirect(w, r, newPath, http.StatusFound)
 }


### PR DESCRIPTION
When a path like mydomain/graph is entered in the URL, maia redirects to mydomain/graph?, which ends up as mydomain/graph again. Endless loop.