### PR TITLE
add support for --columns parameter to query operation

### DIFF
--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -320,7 +320,13 @@ func printQueryResultAsTable(body []byte) {
 			}
 			rows = append(rows, columnValues)
 		}
-		allColumns = append(makeColumns(set), makeColumns(tsSet)...)
+		// have columns be set by user explicitly?
+		if columns != "" {
+			allColumns = strings.Split(columns, ",")
+		} else {
+			allColumns = makeColumns(set)
+		}
+		allColumns = append(allColumns, makeColumns(tsSet)...)
 	case model.ValVector:
 		matrix := valueObject.(model.Vector)
 		set := buildColumnSet(matrix)
@@ -334,12 +340,19 @@ func printQueryResultAsTable(body []byte) {
 			}
 			rows = append(rows, columnValues)
 		}
-		allColumns = append(makeColumns(set), []string{timestampKey, valueKey}...)
+		// have columns be set by user explicitly?
+		if columns != "" {
+			allColumns = strings.Split(columns, ",")
+		} else {
+			allColumns = makeColumns(set)
+		}
+		allColumns = append(allColumns, []string{timestampKey, valueKey}...)
 	case model.ValScalar:
 		scalarValue := valueObject.(*model.Scalar)
 		allColumns = []string{timestampKey, valueKey}
 		rows = []map[string]string{{timestampKey: scalarValue.Timestamp.Time().In(tzLocation).Format(time.RFC3339Nano), valueKey: scalarValue.String()}}
 	}
+
 	printHeader(allColumns)
 	for _, row := range rows {
 		printRow(allColumns, row)

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -277,6 +277,31 @@ func ExampleQuery_table() {
 	// 2017-07-03T07:26:23.997Z 0
 }
 
+func ExampleQuery_tableColumns() {
+	t := testReporter{}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	keystoneMock, storageMock := setupTest(ctrl)
+
+	timestamp = "2019-05-09T12:00:10.724Z"
+	timeoutStr := "1440s"
+	timeout, _ = time.ParseDuration(timeoutStr)
+	query := "limes_domain_quota"
+	outputFormat = "TaBle"
+	columns = "domain"
+
+	expectAuth(keystoneMock)
+	storageMock.EXPECT().Query(query, timestamp, timeoutStr, storage.JSON).Return(test.HTTPResponseFromFile("fixtures/query2.json"), nil)
+
+	queryCmd.RunE(queryCmd, []string{query})
+
+	// Output:
+	// domain __timestamp__ __value__
+	// monsoon3 2019-05-09T12:00:10.724Z 54975581388800
+	// monsoon3 2019-05-09T12:00:10.724Z 11240
+}
+
 func ExampleQuery_rangeJSON() {
 	t := testReporter{}
 	ctrl := gomock.NewController(t)
@@ -371,6 +396,6 @@ func ExampleQuery_rangeSeriesTable() {
 	queryCmd.RunE(queryCmd, []string{query})
 
 	// Output:
-	// check instance region 2017-07-22T20:10:00Z 2017-07-22T20:15:00Z 2017-07-22T20:20:00Z
-	// keystone 100.64.0.102:9102 staging 0 1 0
+	// region check instance 2017-07-22T20:10:00Z 2017-07-22T20:15:00Z 2017-07-22T20:20:00Z
+	// staging keystone 100.64.0.102:9102 0 1 0
 }

--- a/pkg/cmd/fixtures/query2.json
+++ b/pkg/cmd/fixtures/query2.json
@@ -1,0 +1,36 @@
+{
+    "status": "success",
+    "data": {
+        "resultType": "vector",
+        "result": [
+            {
+                "metric": {
+                    "__name__": "limes_domain_quota",
+                    "domain": "monsoon3",
+                    "domain_id": "2bac466eed364d8a92e477459e908736",
+                    "os_cluster": "ccloud",
+                    "resource": "capacity",
+                    "service": "object-store"
+                },
+                "value": [
+                    1557403210.724,
+                    "54975581388800"
+                ]
+            },
+            {
+                "metric": {
+                    "__name__": "limes_domain_quota",
+                    "domain": "monsoon3",
+                    "domain_id": "2bac466eed364d8a92e477459e908736",
+                    "os_cluster": "ccloud",
+                    "resource": "capacity",
+                    "service": "volumev2"
+                },
+                "value": [
+                    1557403210.724,
+                    "11240"
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
before that parameter was silently ignored when using "query"