### PR TITLE
improve error message on /federate w/o scope

### DIFF
--- a/pkg/keystone/keystone.go
+++ b/pkg/keystone/keystone.go
@@ -376,6 +376,8 @@ func (d *keystone) authOptionsFromRequest(r *http.Request, guessScope bool) (*go
 			if err := d.guessScope(&ba); err != nil {
 				return nil, err
 			}
+		} else {
+			return nil, NewAuthenticationError(StatusMissingCredentials, "Basic authorization credentials missing OpenStack authorization scope part")
 		}
 
 		// set password

--- a/pkg/keystone/keystone_test.go
+++ b/pkg/keystone/keystone_test.go
@@ -201,6 +201,20 @@ func TestAuthenticateRequest_failed(t *testing.T) {
 	assertDone(t)
 }
 
+func TestAuthenticateRequest_failedNoScope(t *testing.T) {
+	defer gock.Off()
+
+	ks := setupTest(t)
+
+	req := httptest.NewRequest("GET", "http://maia.local/federate", nil)
+	req.SetBasicAuth("testuser@testdomain", "testpw")
+	_, err := ks.AuthenticateRequest(req, false)
+
+	assert.NotNil(t, err, "AuthenticateRequest should fail with error when scope information is missing for /federate")
+
+	assertDone(t)
+}
+
 func TestAuthenticateRequest_guessScope(t *testing.T) {
 	defer gock.Off()
 


### PR DESCRIPTION
Admins that forget to supply the OpenStack scope information in the username when configuring federation from Maia got a technical error message `No suitable endpoint could be found in the service catalog.`. That does not pinpoint the problem.

With this PR those users will instead get `Basic authorization credentials missing OpenStack authorization scope part` plus they will be prompted to re-enter their credentials when testing the federate endpoint from the browser.