### PR TITLE
add endpoint metrics for more endpoints

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -101,7 +101,7 @@ func setupRouter(keystoneDriver keystone.Driver, storageDriver storage.Driver) h
 	mainRouter.Handle("/metrics", promhttp.Handler())
 
 	// domain-prefixed paths. Order is relevant! This implies that there must be no domain federate, static or graph :-)
-	mainRouter.Methods(http.MethodGet).Path("/{domain}/graph").HandlerFunc(authorize(graph, true, "metric:show"))
+	mainRouter.Methods(http.MethodGet).Path("/{domain}/graph").HandlerFunc(authorize(observeDuration(observeResponseSize(graph, "graph"), "graph"), true, "metric:show"))
 	mainRouter.Methods(http.MethodGet).Path("/{domain}").HandlerFunc(redirectToDomainRootPage)
 
 	// provide the inflight metrics for all paths

--- a/pkg/api/v1api.go
+++ b/pkg/api/v1api.go
@@ -63,9 +63,9 @@ func NewV1Handler(keystoneDriver keystone.Driver, storageDriver storage.Driver) 
 		false,
 		"metric:show"))
 	// tenant-aware label value lists
-	r.Methods(http.MethodGet).Path("/label/{name}/values").HandlerFunc(authorize(p.LabelValues, false, "metric:list"))
+	r.Methods(http.MethodGet).Path("/label/{name}/values").HandlerFunc(authorize(observeDuration(observeResponseSize(p.LabelValues, "label_values"), "label_values"), false, "metric:list"))
 	// tenant-aware series metadata
-	r.Methods(http.MethodGet).Path("/series").HandlerFunc(authorize(p.Series, false, "metric:list"))
+	r.Methods(http.MethodGet).Path("/series").HandlerFunc(authorize(observeDuration(observeResponseSize(p.Series, "series"), "series"), false, "metric:list"))
 
 	return r
 }


### PR DESCRIPTION
this add the duration and response size metrics to '/label/{name}/values', '/series' and '/{domain}/graph'