### PR TITLE
Fix code scanning alert no. 2: Log entries created from user input

### DIFF
--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -57,6 +57,11 @@ func LogDebug(msg string, args ...interface{}) {
 func doLog(msg string, args []interface{}) {
 	msg = strings.TrimSpace(msg)               // most importantly, skip trailing '\n'
 	msg = strings.ReplaceAll(msg, "\n", "\\n") // avoid multiline log messages
+	for i, arg := range args {
+		if str, ok := arg.(string); ok {
+			args[i] = strings.ReplaceAll(strings.ReplaceAll(str, "\n", ""), "\r", "")
+		}
+	}
 	if len(args) > 0 {
 		log.Printf(msg+"\n", args...)
 	} else {


### PR DESCRIPTION
Fixes [https://github.com/sapcc/maia/security/code-scanning/2](https://github.com/sapcc/maia/security/code-scanning/2)

To fix the problem, we need to sanitize the user-provided values in the `args` parameter before logging them. This can be done by replacing newline characters and other potentially dangerous characters in each element of `args`. We will use `strings.ReplaceAll` to remove newline characters from each argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
