### PR TITLE
Register labels endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ All `OS_*` environment variables are supported (e.g., `OS_AUTH_URL`, `OS_USERNAM
 | GET | `/api/v1/query_range` | `metric:show` | Range PromQL query |
 | GET | `/api/v1/series` | `metric:list` | List time series |
 | GET | `/api/v1/label/{name}/values` | `metric:list` | Label values |
-| GET | `/api/v1/labels` | — | **Not registered** (handler exists as dead code in `v1api.go` but no route) |
+| GET | `/api/v1/labels` | `metric:list` | List label names (tenant-aware via `buildSelectors`) |
 | GET | `/federate` | `metric:show` | Prometheus federation endpoint |
 | GET | `/{domain}/graph` | (basic auth) | Expression browser UI |
 | GET | `/metrics` | (none) | Prometheus metrics scrape |

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -209,6 +209,129 @@ func TestSeries_failAuthorization(t *testing.T) {
 	}.Check(t, router)
 }
 
+func TestLabels(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	router, keystoneMock, storageMock := setupTest(t, ctrl)
+
+	expectAuthWithChildren(keystoneMock)
+	storageMock.EXPECT().Labels(
+		"2017-07-01T20:10:30.781Z",
+		"2017-07-02T04:00:00.000Z",
+		[]string{"{component!=\"\",project_id=~\"12345|67890\"}"},
+		storage.JSON,
+	).Return(test.HTTPResponseFromFile("fixtures/labels.json"), nil)
+
+	test.APIRequest{
+		Headers:          map[string]string{"X-Auth-Token": "someverylongtokenideed", "Accept": storage.JSON},
+		Method:           "GET",
+		Path:             "/api/v1/labels?match[]={component!=%22%22}&end=2017-07-02T04:00:00.000Z&start=2017-07-01T20:10:30.781Z",
+		ExpectStatusCode: http.StatusOK,
+		ExpectJSON:       "fixtures/labels.json",
+	}.Check(t, router)
+}
+
+func TestLabels_domainScope(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	router, keystoneMock, storageMock := setupTest(t, ctrl)
+
+	expectAuthByDomainName(keystoneMock)
+	storageMock.EXPECT().Labels(
+		"2017-07-01T20:10:30.781Z",
+		"2017-07-02T04:00:00.000Z",
+		[]string{"{component!=\"\",domain_id=\"77777\"}"},
+		storage.JSON,
+	).Return(test.HTTPResponseFromFile("fixtures/labels.json"), nil)
+
+	test.APIRequest{
+		Headers:          map[string]string{"Authorization": base64.StdEncoding.EncodeToString([]byte("Basic u12345|@77777:password")), "Accept": storage.JSON},
+		Method:           "GET",
+		Path:             "/api/v1/labels?match[]={component!=%22%22}&end=2017-07-02T04:00:00.000Z&start=2017-07-01T20:10:30.781Z",
+		ExpectStatusCode: http.StatusOK,
+		ExpectJSON:       "fixtures/labels.json",
+	}.Check(t, router)
+}
+
+func TestLabels_errorNoMatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	router, keystoneMock, _ := setupTest(t, ctrl)
+
+	expectAuthByProjectID(keystoneMock)
+
+	test.APIRequest{
+		Headers:          map[string]string{"Authorization": base64.StdEncoding.EncodeToString([]byte("Basic user_id|12345:password")), "Accept": storage.JSON},
+		Method:           "GET",
+		Path:             "/api/v1/labels",
+		ExpectStatusCode: http.StatusBadRequest,
+	}.Check(t, router)
+}
+
+func TestLabels_errorInvalidSelector(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	router, keystoneMock, _ := setupTest(t, ctrl)
+
+	expectAuthByProjectID(keystoneMock)
+
+	test.APIRequest{
+		Headers:          map[string]string{"Authorization": base64.StdEncoding.EncodeToString([]byte("Basic user_id|12345:password")), "Accept": storage.JSON},
+		Method:           "GET",
+		Path:             "/api/v1/labels?match[]={invalid_syntax=}",
+		ExpectStatusCode: http.StatusBadRequest,
+	}.Check(t, router)
+}
+
+func TestLabels_errorBackendFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	router, keystoneMock, storageMock := setupTest(t, ctrl)
+
+	expectAuthWithChildren(keystoneMock)
+	storageMock.EXPECT().Labels(
+		"2017-07-01T20:10:30.781Z",
+		"2017-07-02T04:00:00.000Z",
+		[]string{"{component!=\"\",project_id=~\"12345|67890\"}"},
+		storage.JSON,
+	).Return(nil, errors.New("testerror"))
+
+	test.APIRequest{
+		Headers:          map[string]string{"X-Auth-Token": "someverylongtokenideed", "Accept": storage.JSON},
+		Method:           "GET",
+		Path:             "/api/v1/labels?match[]={component!=%22%22}&end=2017-07-02T04:00:00.000Z&start=2017-07-01T20:10:30.781Z",
+		ExpectStatusCode: http.StatusServiceUnavailable,
+	}.Check(t, router)
+}
+
+func TestLabels_failAuthentication(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	router, keystoneMock, _ := setupTest(t, ctrl)
+
+	expectAuthAndFail(keystoneMock)
+
+	test.APIRequest{
+		Method:           "GET",
+		Path:             "/api/v1/labels?match[]={component!=%22%22}&end=2017-07-02T04:00:00.000Z&start=2017-07-01T20:10:30.781Z",
+		ExpectStatusCode: http.StatusUnauthorized,
+	}.Check(t, router)
+}
+
+func TestLabels_failAuthorization(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	router, keystoneMock, _ := setupTest(t, ctrl)
+
+	expectAuthAndDenyAuthorization(keystoneMock)
+
+	test.APIRequest{
+		Method:           "GET",
+		Path:             "/api/v1/labels?match[]={component!=%22%22}&end=2017-07-02T04:00:00.000Z&start=2017-07-01T20:10:30.781Z",
+		ExpectStatusCode: http.StatusForbidden,
+	}.Check(t, router)
+}
+
 func TestLabelValues(t *testing.T) {
 	ctrl := gomock.NewController(t)
 

--- a/pkg/api/fixtures/labels.json
+++ b/pkg/api/fixtures/labels.json
@@ -1,0 +1,8 @@
+{
+  "status": "success",
+  "data": [
+    "__name__",
+    "component",
+    "project_id"
+  ]
+}

--- a/pkg/api/v1api.go
+++ b/pkg/api/v1api.go
@@ -52,6 +52,8 @@ func NewV1Handler(keystoneDriver keystone.Driver, storageDriver storage.Driver) 
 		"metric:show"))
 	// tenant-aware label value lists
 	r.Methods(http.MethodGet).Path("/label/{name}/values").HandlerFunc(authorize(observeDuration(observeResponseSize(p.LabelValues, "label_values"), "label_values"), false, "metric:list"))
+	// tenant-aware label name lists
+	r.Methods(http.MethodGet).Path("/labels").HandlerFunc(authorize(observeDuration(observeResponseSize(p.Labels, "labels"), "labels"), false, "metric:list"))
 	// tenant-aware series metadata
 	r.Methods(http.MethodGet).Path("/series").HandlerFunc(authorize(observeDuration(observeResponseSize(p.Series, "series"), "series"), false, "metric:list"))
 
@@ -207,12 +209,23 @@ func (p *v1Provider) Series(w http.ResponseWriter, req *http.Request) {
 }
 
 func (p *v1Provider) Labels(w http.ResponseWriter, req *http.Request) {
+	ks := getKeystoneFromContext(req.Context())
+	if ks == nil {
+		ReturnPromError(w, errors.New("keystone context not available"), http.StatusInternalServerError)
+		return
+	}
+
+	match, err := buildSelectors(req, ks)
+	if err != nil {
+		ReturnPromError(w, err, http.StatusBadRequest)
+		return
+	}
+
 	queryParams := req.URL.Query()
 	start := queryParams.Get("start")
 	end := queryParams.Get("end")
-	match := queryParams["match[]"]
 
-	resp, err := p.storage.Labels(start, end, match, req.Header.Get("Accept"))
+	resp, err := p.storage.Labels(start, end, *match, req.Header.Get("Accept"))
 	if err != nil {
 		ReturnPromError(w, err, http.StatusServiceUnavailable)
 		return


### PR DESCRIPTION
## Summary

  - register `GET /api/v1/labels` in the v1 API router
  - protect the endpoint with the same auth model as other tenant-aware API routes
  - scope `match[]` selectors through Maia's existing Keystone-based tenant filtering
  - add API tests for project scope, domain scope, invalid selectors, backend failure, auth failure, and authorization failure

  ## Why

  This is backend groundwork for the UI modernization work.

  Maia already had a `Labels()` handler and storage proxy support for `/api/v1/labels`, but the route was not registered. This change
  wires the endpoint and makes it behave like a Maia endpoint rather than a raw Prometheus pass-through.

  ## Test plan

  - `go test ./pkg/api -run 'TestLabels|TestSeries|TestLabelValues'`
  - `go test ./...`