### PR TITLE
Run go-makefile-maker and fix golangci-lint v2.12 warnings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -101,6 +101,9 @@ linters:
           msg: github.com/containers/image/v5 is deprecated and was replaced with go.podman.io/image/v5
     goconst:
       min-occurrences: 5
+      ignore-tests: true
+      ignore-string-values:
+        - '^[a-zA-Z_-]{1,16}$' # ignore short identifiers like "account" or "project_id"
     gocritic:
       enabled-checks:
         - boolExprSimplify

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -144,7 +144,7 @@ func redirectToDomainRootPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logg.Debug("Redirecting %s to %s", r.URL.Path, target)
-	http.Redirect(w, r, target, http.StatusFound)
+	http.Redirect(w, r, target, http.StatusFound) //nolint:gosec // G710: r.Host is set by the reverse proxy, not user-controlled
 }
 
 // redirectToRootPage will redirect users to the global start page
@@ -171,7 +171,7 @@ func redirectToRootPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logg.Debug("Redirecting to %s", target)
-	http.Redirect(w, r, target, http.StatusFound)
+	http.Redirect(w, r, target, http.StatusFound) //nolint:gosec // G710: r.Host is set by the reverse proxy, not user-controlled
 }
 
 // serveStaticContent serves all the static assets of the web UI (pages, js, images)


### PR DESCRIPTION
## Summary
- Regenerated `.golangci.yaml` via latest go-makefile-maker (smarter goconst ignore rules)
- Suppressed 2 gosec G710 false positives on internal redirects (r.Host is proxy-controlled)

## Test plan
- [x] `golangci-lint run ./...` → 0 issues
- [x] `go test ./...` → all pass