### PR TITLE
chore(deps): bump prometheus/prometheus to v0.311.3 (security)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add sentinel label value for global metric visibility (`maia.label_value_for_global_visibility` config option, disabled by default)
+
+### Security
+
+- Bump `github.com/prometheus/prometheus` to v0.311.3 (CVE-2026-42151, CVE-2026-42154, CVE-2026-44903)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
-	github.com/prometheus/prometheus v0.311.2-0.20260410083055-07c6232d159b
+	github.com/prometheus/prometheus v0.311.3
 	github.com/rs/cors v1.11.1
 	github.com/sapcc/go-bits v0.0.0-20260527114813-6f867d03059b
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,6 @@ github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3 h1:6df1vn4bBlDDo
 github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3/go.mod h1:CIWtjkly68+yqLPbvwwR/fjNJA/idrtULjZWh2v1ys0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
-github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -134,8 +132,8 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
-github.com/prometheus/prometheus v0.311.2-0.20260410083055-07c6232d159b h1:tjxqNQlYTJzrQrY7HM2SbnxqzuE64vnvlSmSbAvBBDE=
-github.com/prometheus/prometheus v0.311.2-0.20260410083055-07c6232d159b/go.mod h1:h4Ogksuo6VUZmnm6q/ruKTUzrg9Vvu6u/6O/rQ5xPMg=
+github.com/prometheus/prometheus v0.311.3 h1:3IrVxQv6v5i/ZCGi6OrYeBhtCwaPTn6Z3DYruXoYm3M=
+github.com/prometheus/prometheus v0.311.3/go.mod h1:gjsCxTKtHO1Q8T9333u1s+lUR1OjPyM7ruuGH8RvVyo=
 github.com/prometheus/sigv4 v0.4.1 h1:EIc3j+8NBea9u1iV6O5ZAN8uvPq2xOIUPcqCTivHuXs=
 github.com/prometheus/sigv4 v0.4.1/go.mod h1:eu+ZbRvsc5TPiHwqh77OWuCnWK73IdkETYY46P4dXOU=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=


### PR DESCRIPTION
## Summary

- Bump `github.com/prometheus/prometheus` from pseudo-version `v0.311.2-0.20260410083055-07c6232d159b` to tagged release `v0.311.3`.
- Clears 3 Dependabot advisories on `master`: CVE-2026-42151, CVE-2026-42154, CVE-2026-44903.
- Adds a `### Security` entry under `## [Unreleased]` in CHANGELOG.md.

## Why this is safe

Maia imports only two symbols from `prometheus/prometheus`:

| Package | Used in |
|---------|---------|
| `github.com/prometheus/prometheus/model/labels` | `pkg/util/promqlmod.go` (label injection) |
| `github.com/prometheus/prometheus/promql/parser` | `pkg/util/promqlmod.go` (AST visitor) |

Both APIs are unchanged in the v0.311.2 → v0.311.3 patch release. No call-site updates required. ` + "`govulncheck`" + ` reported zero exploitable call paths even before the bump — Dependabot flagged the manifest match, not reachable code. Bump still required for SBOM/compliance hygiene.

## Validation

Run locally on the branch:

- [x] ` + "`make generate`" + ` (mockgen + go-bindata + addlicense)
- [x] ` + "`make`" + ` (build succeeds)
- [x] ` + "`make check`" + ` (tests + golangci-lint v2 + typos — all green)
- [x] ` + "`go.sum`" + ` regenerated, hashes match upstream

## Test plan

- [ ] CI passes on this branch (lint, tests, REUSE compliance, CodeQL)
- [ ] Dependabot re-resolves the 3 advisories as fixed after merge
- [ ] No new advisories introduced by the upgrade