### PR TITLE
fix(storage): remove dead DelegateRequest to resolve CodeQL SSRF alert

### DIFF
--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -137,7 +137,6 @@ type Driver interface {
 	Series(match []string, start, end string, acceptContentType string) (*http.Response, error)
 	LabelValues(name string, acceptContentType string) (*http.Response, error)
 	Labels(start, end string, match []string, acceptContentType string) (*http.Response, error)
-	DelegateRequest(request *http.Request) (*http.Response, error)
 }
 
 // NewPrometheusDriver is a factory method which chooses the right driver implementation based on configuration settings

--- a/pkg/storage/prometheus.go
+++ b/pkg/storage/prometheus.go
@@ -103,12 +103,6 @@ func (promCli *prometheusStorageClient) Federate(selectors []string, acceptConte
 	return promCli.sendToPrometheus("GET", promURL.String(), nil, map[string]string{"Accept": acceptContentType})
 }
 
-func (promCli *prometheusStorageClient) DelegateRequest(request *http.Request) (*http.Response, error) {
-	promURL := promCli.mapURL(request.URL)
-
-	return promCli.sendToPrometheus(request.Method, promURL.String(), request.Body, map[string]string{"Accept": request.Header.Get("Accept")})
-}
-
 // buildURL is used to build the target URL of a Prometheus call
 func (promCli *prometheusStorageClient) buildURL(path string, params map[string]any) url.URL {
 	promURL := *promCli.url
@@ -136,26 +130,14 @@ func (promCli *prometheusStorageClient) buildURL(path string, params map[string]
 	return promURL
 }
 
-// mapURL is used to map a Maia URL to Prometheus URL
-func (promCli *prometheusStorageClient) mapURL(maiaURL *url.URL) url.URL {
-	promURL := *maiaURL
-
-	// change original request to point to our backing Prometheus
-	promURL.Host = promCli.url.Host
-	promURL.Scheme = promCli.url.Scheme
-	promURL.User = promCli.url.User
-	promURL.RawQuery = ""
-
-	return promURL
-}
-
-// SendToPrometheus takes care of the request wrapping and delivery to Prometheus
+// sendToPrometheus takes care of the request wrapping and delivery to Prometheus.
+//
+//nolint:unparam // method is currently always "GET" but kept generic for API flexibility
 func (promCli *prometheusStorageClient) sendToPrometheus(method, promURL string, body io.Reader, headers map[string]string) (*http.Response, error) {
-	// Validate the URL before proceeding with the request. This is defense-in-depth
-	// against CodeQL go/request-forgery: mapURL() already overwrites Scheme/Host/User
-	// to the trusted upstream, but a future change to mapURL() could regress that
-	// invariant. Rejecting any host other than the configured upstream ensures the
-	// request never leaves the process for a foreign destination.
+	// Defense-in-depth: verify the URL targets a trusted upstream before sending.
+	// All callers construct URLs via buildURL() which uses only the configured
+	// promCli.url / promCli.federateURL base, but this check makes the safety
+	// property explicit and guards against future regressions.
 	if err := promCli.validateUpstreamURL(promURL); err != nil {
 		return nil, err
 	}

--- a/pkg/storage/prometheus.go
+++ b/pkg/storage/prometheus.go
@@ -135,9 +135,9 @@ func (promCli *prometheusStorageClient) buildURL(path string, params map[string]
 //nolint:unparam // method is currently always "GET" but kept generic for API flexibility
 func (promCli *prometheusStorageClient) sendToPrometheus(method, promURL string, body io.Reader, headers map[string]string) (*http.Response, error) {
 	// Defense-in-depth: verify the URL targets a trusted upstream before sending.
-	// All callers construct URLs via buildURL() which uses only the configured
-	// promCli.url / promCli.federateURL base, but this check makes the safety
-	// property explicit and guards against future regressions.
+	// All Driver methods construct URLs via buildURL() which uses only the
+	// configured promCli.url / promCli.federateURL base, but this check makes
+	// the safety property explicit and guards against future regressions.
 	if err := promCli.validateUpstreamURL(promURL); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Removes `DelegateRequest` method and its helper `mapURL` — dead code since 2019 that triggers CodeQL alert #15 (`go/request-forgery`)
- Updates `sendToPrometheus` comment to reflect that all callers now use `buildURL()` exclusively
- Adds `//nolint:unparam` for `method` parameter (always "GET" now that the only non-GET caller is gone)

## Context

CodeQL's `go/request-forgery` rule tracks taint from `DelegateRequest`'s `*http.Request` parameter through `mapURL()` → `sendToPrometheus()` → `httpClient.Do()`. The previous fix (PR #227) added runtime host validation, but CodeQL doesn't recognize custom validators as sanitizers — the alert persisted.

`DelegateRequest` was introduced in 2017 (PR #19) for a generic request-forwarding handler (`forwardRequest`) that was **committed already commented out** and deleted in 2019. It has zero callers — all API endpoints use the typed methods (`Query`, `QueryRange`, `Series`, etc.) via `buildURL()`.

## Verification

- 3 independent analysis passes confirmed dead code (static references, git history, route-handler mapping)
- `make check` passes (tests, golangci-lint, license, build)
- No behavioral change — no code path ever reached `DelegateRequest`

## Test plan

- [x] `make check` passes locally
- [ ] CI green
- [ ] CodeQL re-scan clears alert #15