### PR TITLE
chore: run go-makefile-maker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ build/maia: generate
 static-check: generate
 
 generate: FORCE
-	if ! hash mockgen 2>/dev/null; then go install go.uber.org/mock/mockgen@latest; fi
+	if ! hash mockgen 2>/dev/null; then go install go.uber.org/mock/mockgen@v0.6.0; fi
 	if ! hash go-bindata 2>/dev/null; then go install github.com/go-bindata/go-bindata/go-bindata@v3.1.2+incompatible; fi
-	if ! hash addlicense 2>/dev/null; then go install github.com/google/addlicense@latest; fi
+	if ! hash addlicense 2>/dev/null; then go install github.com/google/addlicense@v1.2.0; fi
 
 	mockgen --source=pkg/storage/interface.go --destination=pkg/storage/genmock.go --package=storage
 	mockgen --source=pkg/keystone/interface.go --destination=pkg/keystone/genmock.go --package=keystone

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -88,9 +88,9 @@ verbatim: |
   static-check: generate
 
   generate: FORCE
-    if ! hash mockgen 2>/dev/null; then go install go.uber.org/mock/mockgen@latest; fi
+    if ! hash mockgen 2>/dev/null; then go install go.uber.org/mock/mockgen@v0.6.0; fi
     if ! hash go-bindata 2>/dev/null; then go install github.com/go-bindata/go-bindata/go-bindata@v3.1.2+incompatible; fi
-    if ! hash addlicense 2>/dev/null; then go install github.com/google/addlicense@latest; fi
+    if ! hash addlicense 2>/dev/null; then go install github.com/google/addlicense@v1.2.0; fi
 
     mockgen --source=pkg/storage/interface.go --destination=pkg/storage/genmock.go --package=storage
     mockgen --source=pkg/keystone/interface.go --destination=pkg/keystone/genmock.go --package=keystone

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -11,6 +11,7 @@ path = [
   ".github/CODEOWNERS",
   ".github/renovate.json",
   ".gitignore",
+  ".hyperspace/pull_request_bot.json",
   ".license-scan-overrides.jsonl",
   ".license-scan-rules.json",
   "build/**/*",


### PR DESCRIPTION
Regenerated with the latest go-makefile-maker. Includes pins for mockgen and addlicense in the generate target and the current REUSE.toml default paths.