### PR TITLE
fix: scrub x-auth-token from request URL after relocating to header

### DIFF
--- a/pkg/keystone/keystone.go
+++ b/pkg/keystone/keystone.go
@@ -424,6 +424,7 @@ func (d *keystone) authOptionsFromRequest(ctx context.Context, r *http.Request, 
 		ba.TokenID = token
 		// relocate to header
 		query.Del("x-auth-token")
+		r.URL.RawQuery = query.Encode()
 		r.Header.Set("X-Auth-Token", ba.TokenID)
 	} else if (appCredID != "" && appCredSecret != "") || (appCredName != "" && appCredUserName != "") {
 		ba.ApplicationCredentialID = appCredID

--- a/pkg/keystone/keystone_test.go
+++ b/pkg/keystone/keystone_test.go
@@ -218,6 +218,45 @@ func TestAuthenticateRequest_token(t *testing.T) {
 	assertDone(t)
 }
 
+func TestAuthenticateRequest_tokenInQueryRemovedFromURL(t *testing.T) {
+	defer gock.Off()
+
+	tests := []struct {
+		name     string
+		rawQuery string
+		wantURL  string
+	}{
+		{
+			name:     "only x-auth-token",
+			rawQuery: "x-auth-token=" + userToken,
+			wantURL:  "",
+		},
+		{
+			name:     "x-auth-token with other params",
+			rawQuery: "match%5B%5D=up&x-auth-token=" + userToken + "&global=true",
+			wantURL:  "global=true&match%5B%5D=up",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ks := setupTest()
+			ctx := t.Context()
+
+			gock.New(baseURL).Get("/v3/auth/tokens").Reply(http.StatusOK).File("fixtures/user_token_validate.json").AddHeader("X-Subject-Token", userToken).AddHeader("Content-Type", "application/json")
+
+			req := httptest.NewRequest(http.MethodGet, "http://maia.local/federate?"+tc.rawQuery, http.NoBody)
+			_, err := ks.AuthenticateRequest(ctx, req, false)
+
+			assert.Nil(t, err, "AuthenticateRequest should not fail")
+			assert.Equal(t, tc.wantURL, req.URL.RawQuery, "x-auth-token should be removed from r.URL.RawQuery")
+			assert.Equal(t, userToken, req.Header.Get("X-Auth-Token"), "token should be relocated to header")
+
+			assertDone(t)
+		})
+	}
+}
+
 func TestAuthenticateRequest_failed(t *testing.T) {
 	defer gock.Off()
 


### PR DESCRIPTION
Write the scrubbed query string back to `r.URL.RawQuery` after moving `x-auth-token` into the `X-Auth-Token` header.